### PR TITLE
update sigs for csgo velocity overlay

### DIFF
--- a/bin/data/game-config.json
+++ b/bin/data/game-config.json
@@ -302,8 +302,7 @@
             "signature": "int(__cdecl*)()",
             "value": {
                 "library": "client.dll",
-                "pattern": "E8 ?? ?? ?? ?? 85 C0 74 17 E8 ?? ?? ?? ??",
-                "relative-jump": true
+                "pattern": "8B 0D ?? ?? ?? ?? 85 C9 74 ?? 8B 01 FF A0 ?? ?? ?? ?? 33 C0 C3"
             }
         },
         {
@@ -323,7 +322,7 @@
             "signature": "void*(__cdecl*)(int index)",
             "value": {
                 "library": "client.dll",
-                "pattern": "83 F9 01 7C 39 A1 ?? ?? ?? ?? 3B 48 18 7F 2F C1 E1 04 56 8B 89 ?? ?? ?? ?? 85 C9 74 1B 8B 01 FF 50 1C 8B F0 85 F6 74 10 8B 06 8B CE 8B 80 ?? ?? ?? ?? FF D0 84 C0"
+                "pattern": "83 F9 01 7C ?? A1 ?? ?? ?? ?? 3B 48 ?? 7F ?? 56"
             }
         },
         {
@@ -341,7 +340,7 @@
             "config-id": "config-001-player-abs-velocity-offset",
             "signature": "ptrdiff_t",
             "value": {
-                "offset": 37
+                "offset": 69
             }
         }
     ],

--- a/projects/svr_game/src/arch_000_source_1_win.cpp
+++ b/projects/svr_game/src/arch_000_source_1_win.cpp
@@ -52,6 +52,7 @@ static bool is_velocity_overlay_allowed(svr::game_config_game* game)
     const char* allowed_ids[] = {
         "css-win",
         "mom-win",
+        "csgo-win",
     };
 
     for (auto i : allowed_ids)
@@ -142,13 +143,10 @@ static void process_velocity_overlay()
 
     auto spec = get_spec_target();
 
-    // TODO
-    // This is always 0 for csgo, so this procedure doesn't work for that game.
-    // Through cheat engine, the variable which contains the spectate played id has been found, but it's
-    // in another location and not in the local player.
     if (spec > 0)
     {
-        player = get_player_by_index(spec);
+        auto target = get_player_by_index(spec);
+        player = (target != 0) ? target : player;
     }
 
     vec3 vel;


### PR DESCRIPTION
This updates the CSGO sigs to `GetSpectatorTarget` and `UTIL_PlayerByIndex`.

Also, I noticed that `config-001-player-abs-velocity-offset` (37) seemed to result in the player being show as 0 velocity when in thirdperson mode spectating someone, so I swapped it to 69 (nice) which should be `m_vecVelocity`. Since the CSS offset is really close at 61, I think it actually mean that CSS is using `m_vecVelocity` too instead of `m_vecAbsVelocity`.

Since this was mostly trial and error looking at disassembly and testing the offsets, I might have something wrong, but everything works so far for me in some test demos that include switching between players and thirdperson.