### PR TITLE
A very crude PR to make it (somewhat) work on win 7.

### DIFF
--- a/shaders/motion_sample.hlsl
+++ b/shaders/motion_sample.hlsl
@@ -1,10 +1,10 @@
-Texture2D<unorm float4> source_texture : register(t0);
+Texture2D<unorm float> source_texture : register(t0);
 
 // If the hardware does not support typed UAV loads for R32G32B32A32_FLOAT then we have to do more work.
 // We need to use 32 bits per component in order to retain the accuracy of blending together multiple textures.
 // If we don't have the hardware support for this texture format, we need to use a memory buffer.
 
-RWTexture2D<float4> dest_texture : register(u0);
+RWTexture2D<float> dest_texture : register(u0);
 
 cbuffer mosample_buffer_0 : register(b0)
 {
@@ -17,7 +17,7 @@ void main(uint3 dtid : SV_DispatchThreadID)
 {
     uint2 pos = dtid.xy;
 
-    float4 source_pix = source_texture.Load(dtid);
+    float source_pix = source_texture.Load(dtid);
 
     dest_texture[pos] += source_pix * mosample_weight;
 }

--- a/src/game_standalone.cpp
+++ b/src/game_standalone.cpp
@@ -829,7 +829,8 @@ bool run_cfg(const char* name)
     // Commands must end with a newline, also need to terminate.
 
     mem = (char*)malloc(file_size.LowPart + 2);
-    ReadFile(h, mem, file_size.LowPart, NULL, NULL);
+    DWORD nr;
+    ReadFile(h, mem, file_size.LowPart, &nr, NULL);
     mem[file_size.LowPart - 1] = '\n';
     mem[file_size.LowPart] = 0;
 

--- a/src/launcher_main.cpp
+++ b/src/launcher_main.cpp
@@ -525,6 +525,9 @@ s32 start_game(s32 game_index)
     char GAME_DLL_NAME[] = "svr_game.dll";
     char INIT_FN_NAME[] = "svr_init_standalone";
 
+    launcher_log("GAME_DLL_NAME: %s\n", GAME_DLL_NAME);
+    launcher_log("INIT_FN_NAME: %s\n", INIT_FN_NAME);
+    launcher_log("working_dir: %s\n", working_dir);
     WriteProcessMemory(info.hProcess, (char*)remote_mem + remote_write_pos, GAME_DLL_NAME, SVR_ARRAY_SIZE(GAME_DLL_NAME), &remote_written);
     structure.library_name = (char*)remote_mem + remote_write_pos;
     remote_write_pos += remote_written;
@@ -825,6 +828,8 @@ void find_steam_libraries()
 
     SvrVdfMem vdf_mem;
 
+    svr_log(full_vdf_path);
+
     if (!svr_open_vdf_read(full_vdf_path, &vdf_mem))
     {
         // Not having any extra Steam libraries is ok.
@@ -985,17 +990,12 @@ void check_hw_caps()
     svr_log("Using graphics device %x by vendor %x\n", dxgi_adapter_desc.DeviceId, dxgi_adapter_desc.VendorId);
 
     D3D11_FEATURE_DATA_FORMAT_SUPPORT2 fmt_support2;
-    fmt_support2.InFormat = DXGI_FORMAT_R32G32B32A32_FLOAT;
+    fmt_support2.InFormat = DXGI_FORMAT_R32_FLOAT;
     d3d11_device->CheckFeatureSupport(D3D11_FEATURE_FORMAT_SUPPORT2, &fmt_support2, sizeof(D3D11_FEATURE_DATA_FORMAT_SUPPORT2));
 
     bool has_typed_uav_load = fmt_support2.OutFormatSupport2 & D3D11_FORMAT_SUPPORT2_UAV_TYPED_LOAD;
     bool has_typed_uav_store = fmt_support2.OutFormatSupport2 & D3D11_FORMAT_SUPPORT2_UAV_TYPED_STORE;
     bool has_typed_uav_support = has_typed_uav_load && has_typed_uav_store;
-
-    if (!has_typed_uav_support)
-    {
-        launcher_error("This system does not meet the requirements to use SVR.");
-    }
 }
 
 int main(int argc, char** argv)
@@ -1025,10 +1025,6 @@ int main(int argc, char** argv)
 
     // Enable to show system information and stuff on start.
     #if 1
-    if (!IsWindows10OrGreater())
-    {
-        launcher_error("Windows 10 or later is needed to use SVR.");
-    }
 
     SYSTEMTIME lt;
     GetLocalTime(&lt);

--- a/src/svr_api.cpp
+++ b/src/svr_api.cpp
@@ -57,6 +57,22 @@ void free_all_dynamic_svr_stuff()
     svr_maybe_release(&svr_content_rtv);
 }
 
+#include <stb_sprintf.h>
+static void standalone_error(const char* format, ...)
+{
+    char message[1024];
+
+    va_list va;
+    va_start(va, format);
+    stbsp_vsnprintf(message, 1024, format, va);
+    va_end(va);
+
+    svr_log("!!! ERROR: %s\n", message);
+
+    // MB_TASKMODAL or MB_APPLMODAL flags do not work.
+
+    MessageBoxA(NULL, message, "SVR", MB_ICONERROR | MB_OK);
+}
 bool svr_init(const char* svr_path, IUnknown* game_device)
 {
     bool ret = false;
@@ -66,7 +82,7 @@ bool svr_init(const char* svr_path, IUnknown* game_device)
 
     if (svr_d3d11_device == NULL && svr_d3d9ex_device == NULL)
     {
-        OutputDebugStringA("SVR (svr_init): The passed game_device is not a D3D11 (ID3D11Device) or a D3D9Ex (IDirect3DDevice9Ex) type\n");
+        standalone_error("SVR (svr_init): The passed game_device is not a D3D11 (ID3D11Device) or a D3D9Ex (IDirect3DDevice9Ex) type\n");
         goto rfail;
     }
 
@@ -79,20 +95,20 @@ bool svr_init(const char* svr_path, IUnknown* game_device)
 
         if (device_level < (UINT)D3D_FEATURE_LEVEL_11_0)
         {
-            OutputDebugStringA("SVR (svr_init): The game D3D11 device must be created with D3D_FEATURE_LEVEL_11_0 or higher\n");
+            standalone_error("SVR (svr_init): The game D3D11 device must be created with D3D_FEATURE_LEVEL_11_0 or higher\n");
             goto rfail;
         }
 
         if (!(device_flags & D3D11_CREATE_DEVICE_BGRA_SUPPORT))
         {
-            OutputDebugStringA("SVR (svr_init): The game D3D11 device must be created with the D3D11_CREATE_DEVICE_BGRA_SUPPORT flag\n");
+            standalone_error("SVR (svr_init): The game D3D11 device must be created with the D3D11_CREATE_DEVICE_BGRA_SUPPORT flag\n");
             goto rfail;
         }
 
         #if SVR_DEBUG
         if (device_flags & D3D11_CREATE_DEVICE_DEBUG)
         {
-            OutputDebugStringA("SVR (svr_init): The game D3D11 device has the debug layer enabled\n");
+            standalone_error("SVR (svr_init): The game D3D11 device has the debug layer enabled\n");
         }
         #endif
 
@@ -127,7 +143,7 @@ bool svr_init(const char* svr_path, IUnknown* game_device)
 
         if (FAILED(hr))
         {
-            svr_log("ERROR: Could not create D3D11 device (%#x)\n", hr);
+            standalone_error("ERROR: Could not create D3D11 device (%#x)\n", hr);
             goto rfail;
         }
     }

--- a/src/svr_game.vcxproj
+++ b/src/svr_game.vcxproj
@@ -43,7 +43,7 @@
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{0B116E75-C1CC-409B-A50A-274DC2D4CB41}</ProjectGuid>
     <RootNamespace>svr_game</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/src/svr_ini.cpp
+++ b/src/svr_ini.cpp
@@ -118,7 +118,8 @@ bool svr_open_ini_read(const char* path, SvrIniMem* mem)
     {
         mem->mem = malloc(large.LowPart + 1);
 
-        ReadFile(h, mem->mem, large.LowPart, NULL, NULL);
+        DWORD nr;
+        ReadFile(h, mem->mem, large.LowPart, &nr, NULL);
 
         mem->mov_str = (char*)mem->mem;
         mem->mov_str[large.LowPart] = 0;

--- a/src/svr_launcher.vcxproj
+++ b/src/svr_launcher.vcxproj
@@ -35,7 +35,7 @@
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{E750167E-861F-4CF4-9F5D-20F473129641}</ProjectGuid>
     <RootNamespace>svr_launcher</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/src/svr_logging.cpp
+++ b/src/svr_logging.cpp
@@ -11,7 +11,8 @@ HANDLE log_file_handle;
 void log_function(const char* text, s32 length)
 {
     assert(log_file_handle);
-    WriteFile(log_file_handle, text, length, NULL, NULL);
+    DWORD w;
+    WriteFile(log_file_handle, text, length, &w, NULL);
 }
 
 void svr_init_log(const char* log_file_path, bool append)

--- a/src/svr_sem.cpp
+++ b/src/svr_sem.cpp
@@ -22,7 +22,7 @@ void svr_sem_release(SvrSemaphore* sem)
 
         if (prev_count == (LONG)orig_count)
         {
-            WakeByAddressSingle(&sem->count);
+            //WakeByAddressSingle(&sem->count);
             return;
         }
     }
@@ -36,7 +36,8 @@ void svr_sem_wait(SvrSemaphore* sem)
 
         while (orig_count == 0)
         {
-            WaitOnAddress(&sem->count, &orig_count, sizeof(s32), INFINITE);
+            //WaitOnAddress(&sem->count, &orig_count, sizeof(s32), INFINITE);
+            Sleep(10);
             orig_count = sem->count;
         }
 

--- a/src/svr_vdf.cpp
+++ b/src/svr_vdf.cpp
@@ -154,7 +154,8 @@ bool svr_open_vdf_read(const char* path, SvrVdfMem* mem)
     {
         mem->mem = malloc(large.LowPart + 1);
 
-        ReadFile(h, mem->mem, large.LowPart, NULL, NULL);
+        DWORD aa;
+        ReadFile(h, mem->mem, large.LowPart, &aa, NULL);
 
         mem->mov_str = (char*)mem->mem;
         mem->mov_str[large.LowPart] = 0;


### PR DESCRIPTION
This PR is a mush of related and unrelated changes. It's just whatever I ended up with. Two things that are not working are:
- velocity rendering - because I had issues with compiling, missing properties in some d3dx struct
- motion blur - because lacks `DXGI_FORMAT_R32G32B32A32_FLOAT` for uavs, there might be a workaround but I never did anything with d3dx and after a few tries I don't think I can do it. The best way might be to have one uav per channel, but no idea how to declare that and pass it through to the next shader.

These are minor features, and overall it's usable.

Obviously shouldn't be merged in this state. The crucial things are:

- `WriteFile` and `ReadFile` must take non-null pointer to the number of read/written bytes. The docs state "This parameter can be NULL only when the lpOverlapped parameter is not NULL.", so I'm not sure how this even works on win 10? Perhaps there's some note I'm missing
- The `motion_sample` uses `DXGI_FORMAT_R32G32B32A32_FLOAT` which is only available since D3DX11.3, but since the shader performs the same operation for all elements *I think* `DXGI_FORMAT_R32_FLOAT` (D1DX11) can be used instead without problems. (edit. It actually doesn't work, but the output for no motion blur is not affected. It *should* be possible to do this piecewise but I don't know how to set it up in the d3dx)
- `WaitOnAddress` is available only since windows 8. A temporary fix applied here is to use a sleep, which is not guaranteed to work and may break in release builds. A proper fix would be to use standard C++ primitives for locking.
- `WakeByAddressSingle` similarly, this function is only available since windows 8. It's not needed with the sleep workaround here.

The unrelated changes are mostly changing the way the [error] logging is done.