### PR TITLE
Adjust get_active_player for CSGO velocity overlay

### DIFF
--- a/src/game_standalone.cpp
+++ b/src/game_standalone.cpp
@@ -465,16 +465,12 @@ void* get_active_player()
 {
     s32 spec = get_spec_target();
 
-    void* player;
+    void* player = get_local_player();
 
     if (spec > 0)
     {
-        player = get_player_by_idx(spec);
-    }
-
-    else
-    {
-        player = get_local_player();
+        auto target = get_player_by_idx(spec);
+        player = (target != 0) ? target : player;
     }
 
     return player;


### PR DESCRIPTION
Without this change, spectating a player (maybe only bots?) will give 0 for the velocity in CSGO.

This is the same logic from #43 where `player` is localplayer unless the spec player is non-zero.
https://github.com/crashfort/SourceDemoRender/pull/43/files#diff-b0fb65317d8a6329701a83425db27f20df149a4b73a59a63a9f391ce238f3595L143-L152

Not sure why it's necessary tbh but /shrug

Also it might be good to replace `get_player_by_idx` with `get_entity_by_idx` eventually (if such a function exists in the source-engine) since non-player entities can be set as the observee.

@crashfort 
