### PR TITLE
Add new CSGO pattern for get_spec_target_fn (02-02-2022)

### DIFF
--- a/src/game_standalone.cpp
+++ b/src/game_standalone.cpp
@@ -1370,7 +1370,7 @@ void* get_get_spec_target_fn()
 
         case STEAM_GAME_CSGO:
         {
-            return pattern_scan("client.dll", "55 8B EC 8B 4D 04 8B C1 83 C0 08 8B 0D ?? ?? ?? ?? 85 C9 74 15 8B 01 FF 90 ?? ?? ?? ?? 85 C0 74 09 8D 48 08 8B 01 5D FF 60 28", __FUNCTION__);
+            return pattern_scan("client.dll", "55 8B EC 8B 4D ?? E8 ?? ?? ?? ?? 8B 0D ?? ?? ?? ?? 85 C9 74 ?? 8B 01 FF 90 ?? ?? ?? ?? 85 C0 74 ?? 8D 48", __FUNCTION__);
         }
 
         default: assert(false);

--- a/src/launcher_main.cpp
+++ b/src/launcher_main.cpp
@@ -96,7 +96,7 @@ const char* GAME_EXE_PATHS[] = {
 // Build versions that have been tested (located in the appmanifest acf).
 s32 GAME_BUILDS[] = {
     6946501, // STEAM_GAME_CSS
-    7866056, // STEAM_GAME_CSGO
+    8128170, // STEAM_GAME_CSGO
     7504322, // STEAM_GAME_TF2
     5972042, // STEAM_GAME_ZPS
     4233294, // STEAM_GAME_HL2


### PR DESCRIPTION
Closes #59

#

Built from [master](https://github.com/crashfort/SourceDemoRender/tree/master): https://cdn.discordapp.com/attachments/674321047083941909/938384456073502720/svr_updatedcsgopattern_orig.zip

Built from [csgo-vel-overlay-target-fix](https://github.com/rtldg/SourceDemoRender/tree/csgo-vel-overlay-target-fix): https://cdn.discordapp.com/attachments/674321047083941909/938384477699330088/svr_updatedcsgopattern_with_rtldg_spec_fixes.zip